### PR TITLE
Fix docstring typos

### DIFF
--- a/torch/utils/_import_utils.py
+++ b/torch/utils/_import_utils.py
@@ -7,9 +7,9 @@ import torch
 
 
 def _check_module_exists(name: str) -> bool:
-    r"""Returns if a top-level module with :attr:`name` exists *without**
-    importing it. This is generally safer than try-catch block around a
-    `import X`. It avoids third party libraries breaking assumptions of some of
+    r"""Returns if a top-level module with :attr:`name` exists *without*
+    importing it. This is generally safer than a try/except block around an
+    ``import X``. It avoids third party libraries breaking assumptions of some of
     our tests, e.g., setting multiprocessing start method when imported
     (see librosa/#747, torchvision/#544).
     """

--- a/torch/utils/data/graph.py
+++ b/torch/utils/data/graph.py
@@ -110,7 +110,7 @@ def traverse(datapipe: DataPipe, only_datapipe: Optional[bool] = None) -> DataPi
     Traverse the DataPipes and their attributes to extract the DataPipe graph.
 
     [Deprecated]
-    When ``only_dataPipe`` is specified as ``True``, it would only look into the
+    When ``only_datapipe`` is specified as ``True``, it would only look into the
     attribute from each DataPipe that is either a DataPipe and a Python collection object
     such as ``list``, ``tuple``, ``set`` and ``dict``.
 


### PR DESCRIPTION
## Summary
- fix formatting in `_check_module_exists` docstring
- correct argument name in `traverse` docstring

## Testing
- `python -m py_compile torch/utils/_import_utils.py torch/utils/data/graph.py`

------
https://chatgpt.com/codex/tasks/task_e_6840eb7ca58c8323ae1eeafa76424d8c